### PR TITLE
fix: remove 3 duplicate DiffFilingMetadata test assertions

### DIFF
--- a/.sageox/distill-state-v2.json
+++ b/.sageox/distill-state-v2.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "2",
+  "team_id": "",
+  "last_daily": "2026-03-12T20:40:23Z",
+  "last_weekly": "2026-03-12T20:40:23Z",
+  "last_monthly": "2026-03-12T20:40:23Z",
+  "daily_count": 17,
+  "last_daily_hash": "f035988ea3b7fef0",
+  "last_weekly_hash": "80d809432d6ef35d",
+  "last_monthly_hash": "8bf22bf4e4d10671",
+  "processed_discussions": {
+    "2026-03-10-06-20-galex": "53637c116b4bba92",
+    "2026-03-10-07-05-galex": "fc38e7c5e4072680",
+    "2026-03-12-04-26-galex": "29f253ced10c71d7",
+    "2026-03-12-04-50-galex": "0eab81dadc3a32c0"
+  }
+}

--- a/libs/edgar-diff-lib/tests/e2e/diff/diff-pipeline.e2e.test.ts
+++ b/libs/edgar-diff-lib/tests/e2e/diff/diff-pipeline.e2e.test.ts
@@ -34,11 +34,6 @@ describe('E2E: Full diff pipeline (parseFiling -> diffFilings)', () => {
   it('E2E-1: parseFiling -> diffFilings produces complete StructuredDiff', () => {
     const result = diffFilings(oldDoc, newDoc);
 
-    // DiffFilingMetadata — value equality, no html
-    expect(result.oldFiling.accessionNumber).toBe(oldFiling.accessionNumber);
-    expect(result.newFiling.accessionNumber).toBe(newFiling.accessionNumber);
-    expect('html' in result.oldFiling).toBe(false);
-    expect('html' in result.newFiling).toBe(false);
     expect(result.sectionDiffs).toBeDefined();
     expect(result.sectionDiffs.length).toBeGreaterThan(0);
     expect(result.summary).toBeDefined();

--- a/libs/edgar-diff-lib/tests/integration/diff-pipeline.integration.test.ts
+++ b/libs/edgar-diff-lib/tests/integration/diff-pipeline.integration.test.ts
@@ -192,42 +192,6 @@ describe('diff pipeline integration', () => {
     }
   });
 
-  it('I-DP-5: metadata references are preserved through pipeline', () => {
-    const oldDoc = makeStructuredDoc([
-      makeSection('item-1', 'Item 1. Business', [
-        makeParagraph('Text', 100),
-        makeTable([['A', 'B']], 200),
-      ]),
-    ]);
-
-    const newDoc = makeStructuredDoc([
-      makeSection('item-1', 'Item 1. Business', [
-        makeParagraph('Text updated', 100),
-        makeTable([['A', 'C']], 200),
-      ]),
-    ]);
-
-    const result = diffFilings(oldDoc, newDoc);
-
-    // DiffFilingMetadata — value equality (no longer reference equality), no html
-    expect(result.oldFiling.accessionNumber).toBe(oldDoc.filing.accessionNumber);
-    expect(result.oldFiling.cik).toBe(oldDoc.filing.cik);
-    expect(result.newFiling.accessionNumber).toBe(newDoc.filing.accessionNumber);
-    expect(result.newFiling.cik).toBe(newDoc.filing.cik);
-    expect('html' in result.oldFiling).toBe(false);
-    expect('html' in result.newFiling).toBe(false);
-
-    // Metadata fields are accessible
-    expect(result.oldFiling.accessionNumber).toBeDefined();
-    expect(result.oldFiling.cik).toBeDefined();
-    expect(result.oldFiling.formType).toBeDefined();
-    expect(result.oldFiling.filingDate).toBeDefined();
-    expect(result.newFiling.accessionNumber).toBeDefined();
-    expect(result.newFiling.cik).toBeDefined();
-    expect(result.newFiling.formType).toBeDefined();
-    expect(result.newFiling.filingDate).toBeDefined();
-  });
-
   it('I-DP-6: diffFilings with multi-section documents containing tables', () => {
     const oldDoc = makeStructuredDoc([
       makeSection('item-1', 'Item 1. Business', [

--- a/libs/edgar-diff-lib/tests/unit/diff-filings.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/diff-filings.test.ts
@@ -33,16 +33,6 @@ describe('diff-filings', () => {
     expect(result.summary.unchanged).toBe(1);
     expect(result.summary.added).toBe(0);
     expect(result.summary.removed).toBe(0);
-
-    // BQ6: oldFiling/newFiling are DiffFilingMetadata (no html)
-    expect(result.oldFiling.accessionNumber).toBe(oldDoc.filing.accessionNumber);
-    expect(result.oldFiling.cik).toBe(oldDoc.filing.cik);
-    expect(result.oldFiling.formType).toBe(oldDoc.filing.formType);
-    expect(result.oldFiling.filingDate).toBeDefined();
-    expect(result.oldFiling.primaryDocumentFilename).toBeDefined();
-    expect(result.oldFiling.fetchedAt).toBeDefined();
-    expect('html' in result.oldFiling).toBe(false);
-    expect('html' in result.newFiling).toBe(false);
   });
 
   // DF-U2: Subsection flattening — top-level sections are aligned


### PR DESCRIPTION
## Summary
- Removed duplicate `DiffFilingMetadata` (no html) assertions from 3 test files
- Kept the canonical test in `diff-engine.test.ts` (DE-S5), which covers all assertions the duplicates had
- Removed: metadata checks in DF-U1 (`diff-filings.test.ts`), entire I-DP-5 test (`diff-pipeline.integration.test.ts`), metadata checks in E2E-1 (`diff-pipeline.e2e.test.ts`)

Closes edgar-diff-tg7

## Test plan
- [x] All 4839 tests pass in worktree
- [x] Verified DE-S5 is a strict superset of every removed assertion
- [x] Confirmed E2E-2 still tests metadata absence after JSON round-trip with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)