### PR TITLE
fix: eliminate cross-tier overlap in diff/alignment tests

### DIFF
--- a/libs/edgar-diff-lib/tests/integration/paragraph-differ.integration.test.ts
+++ b/libs/edgar-diff-lib/tests/integration/paragraph-differ.integration.test.ts
@@ -78,14 +78,8 @@ describe('PD-I2: cross-year diff detects modifications', () => {
     const allParagraphDiffs = result.sectionDiffs.flatMap(sd => sd.paragraphDiffs);
     const modified = allParagraphDiffs.filter(pd => pd.changeType === 'modified');
 
+    // Integration concern: the pipeline produces modified paragraphs from real filings
     expect(modified.length).toBeGreaterThan(0);
-
-    // Modified paragraphs should have word-level diffs
-    for (const m of modified) {
-      const wordChanges = m.wordChanges;
-      assertDefined(wordChanges);
-      expect(wordChanges.length).toBeGreaterThan(0);
-    }
   });
 });
 

--- a/libs/edgar-diff-lib/tests/unit/table-differ.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/table-differ.test.ts
@@ -4,15 +4,8 @@ import { diffTable, diffTables } from '../../src/diff/table-differ.js';
 import { makeTable, makeTableRow, makeTableCell, makeFinancialTable } from '../helpers/table-diff-helpers.js';
 
 describe('row alignment', () => {
-  it('identical rows => unchanged, rowDiffs empty (unchanged rows filtered)', () => {
-    const table = makeFinancialTable({
-      headers: ['Metric', '2023'],
-      rows: [{ label: 'Revenue', values: ['$100'] }],
-    });
-    const result = diffTable(table, table);
-    expect(result.changeType).toBe('unchanged');
-    expect(result.rowDiffs).toEqual([]);
-  });
+  // "identical rows => unchanged" removed: subsumed by AC-2 acceptance test
+  // which verifies this invariant across 200 randomly generated table pairs.
 
   it('inserted row in the middle => RowDiff with changeType added, newRowIndex set', () => {
     const oldTable = makeTable([


### PR DESCRIPTION
## Summary

- Remove redundant unit test for identical-tables-unchanged in `table-differ.test.ts` — subsumed by acceptance test AC-2 (200 randomly generated table pairs testing the same invariant)
- Strip duplicated `wordChanges` assertions from PD-I2 in `paragraph-differ.integration.test.ts` — unit test PD-U4 already covers this contract; integration test now focuses on pipeline producing modified paragraphs

## Analysis

The issue identified 3 areas of cross-tier overlap. After analysis, only 2 held up:

| Claim | Verdict | Action |
|-------|---------|--------|
| Section alignment (U-AS-4 vs I-2 vs AC-1) | **Not redundant** — each tier tests different behavior (heading match, item-number logic, generalization) | No change |
| Paragraph differ (PD-U4 vs PD-I2) | **Partial overlap** — PD-I2 re-verified unit-level wordChanges contract | Removed duplicated assertion |
| Table differ (unit vs AC-2) | **Redundant** — unit test is single hardcoded case, AC-2 covers 200 random cases | Removed unit test |

## Test plan

- [x] All 4827 tests pass
- [x] Typecheck clean

Closes edgar-diff-3ed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: SageOx <ox@sageox.ai>