### PR TITLE
fix: remove trivial and too-simple tests

### DIFF
--- a/libs/edgar-diff-lib/tests/acceptance/table-extractor.acceptance.test.ts
+++ b/libs/edgar-diff-lib/tests/acceptance/table-extractor.acceptance.test.ts
@@ -182,11 +182,6 @@ describe('property: numeric parsing through pipeline', () => {
 // ============================================================
 
 describe('property: edge-case tables handled gracefully', () => {
-  it('empty table (0 rows) does not throw', () => {
-    const html = wrapInSection('<table></table>');
-    expect(() => parseFiling(makeRawFiling(html))).not.toThrow();
-  });
-
   it('single-cell table works correctly', () => {
     const html = wrapInSection('<table><tr><td>Only cell</td></tr></table>');
     const doc = parseFiling(makeRawFiling(html));
@@ -195,15 +190,6 @@ describe('property: edge-case tables handled gracefully', () => {
     expect(table.rows).toHaveLength(1);
     expect(table.rows[0].cells).toHaveLength(1);
     expect(table.rows[0].cells[0].text).toBe('Only cell');
-  });
-
-  it('table with empty rows does not throw', () => {
-    const html = wrapInSection('<table><tr></tr><tr><td>Valid</td></tr></table>');
-    expect(() => parseFiling(makeRawFiling(html))).not.toThrow();
-    const doc = parseFiling(makeRawFiling(html));
-    const table = doc.sections[0]?.blocks.find(b => b.type === 'table') as Table;
-    expect(table).toBeDefined();
-    expect(table.rows.some(r => r.cells.length > 0)).toBe(true);
   });
 
   it('very large table (100+ rows) does not crash', () => {
@@ -216,11 +202,6 @@ describe('property: edge-case tables handled gracefully', () => {
     const table = doc.sections[0]?.blocks.find(b => b.type === 'table') as Table;
     expect(table).toBeDefined();
     expect(table.rows).toHaveLength(100);
-  });
-
-  it('malformed table HTML does not throw', () => {
-    const html = wrapInSection('<table><tr><td>Cell 1<td>Cell 2<tr><td>Cell 3</table>');
-    expect(() => parseFiling(makeRawFiling(html))).not.toThrow();
   });
 
   it('table with invalid colspan/rowspan does not throw', () => {

--- a/libs/edgar-diff-lib/tests/unit/diff-types.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/diff-types.test.ts
@@ -30,52 +30,6 @@ function buildMixedDiff(): ParagraphDiff[] {
 describe('diff type contracts', () => {
   const changes = buildMixedDiff();
 
-  // DT-U1: added entries have sourceMapping.new, no sourceMapping.old
-  it('DT-U1: added entries have sourceMapping.new, no sourceMapping.old', () => {
-    const added = changes.filter(c => c.changeType === 'added');
-    for (const c of added) {
-      expect(c.sourceMapping.new).toBeDefined();
-      expect(c.sourceMapping.old).toBeUndefined();
-    }
-  });
-
-  // DT-U2: removed entries have sourceMapping.old, no sourceMapping.new
-  it('DT-U2: removed entries have sourceMapping.old, no sourceMapping.new', () => {
-    const removed = changes.filter(c => c.changeType === 'removed');
-    for (const c of removed) {
-      expect(c.sourceMapping.old).toBeDefined();
-      expect(c.sourceMapping.new).toBeUndefined();
-    }
-  });
-
-  // DT-U3: modified entries have both sources
-  it('DT-U3: modified entries have both sourceMapping.old and sourceMapping.new', () => {
-    const modified = changes.filter(c => c.changeType === 'modified');
-    for (const c of modified) {
-      expect(c.sourceMapping.old).toBeDefined();
-      expect(c.sourceMapping.new).toBeDefined();
-    }
-  });
-
-  // DT-U4: unchanged entries have both sources
-  it('DT-U4: unchanged entries have both sourceMapping.old and sourceMapping.new', () => {
-    const unchanged = changes.filter(c => c.changeType === 'unchanged');
-    expect(unchanged.length).toBeGreaterThan(0);
-    for (const c of unchanged) {
-      expect(c.sourceMapping.old).toBeDefined();
-      expect(c.sourceMapping.new).toBeDefined();
-    }
-  });
-
-  // DT-U5: moved entries have both sources
-  it('DT-U5: moved entries have both sourceMapping.old and sourceMapping.new', () => {
-    const moved = changes.filter(c => c.changeType === 'moved');
-    for (const c of moved) {
-      expect(c.sourceMapping.old).toBeDefined();
-      expect(c.sourceMapping.new).toBeDefined();
-    }
-  });
-
   // DT-U6: Source locations satisfy start >= 0, start < end
   it('DT-U6: source locations have valid ranges', () => {
     for (const c of changes) {

--- a/libs/edgar-diff-lib/tests/unit/diff/diff-engine.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/diff/diff-engine.test.ts
@@ -62,31 +62,6 @@ describe('buildSummary', () => {
 });
 
 describe('diffFilings', () => {
-  it('U-DF-1: returns valid StructuredDiff shape', () => {
-    const { oldDoc, newDoc } = makeDocumentPair(
-      [{ id: 'item-1', heading: 'Item 1. Business', content: 'text' }],
-      [{ id: 'item-1', heading: 'Item 1. Business', content: 'text' }],
-    );
-    const result = diffFilings(oldDoc, newDoc);
-    expect(result).toHaveProperty('oldFiling');
-    expect(result).toHaveProperty('newFiling');
-    expect(result).toHaveProperty('sectionDiffs');
-    expect(result).toHaveProperty('summary');
-    expect(result).toHaveProperty('generatedAt');
-  });
-
-  it('U-DF-2: oldFiling and newFiling are DiffFilingMetadata (no html)', () => {
-    const { oldDoc, newDoc } = makeDocumentPair(
-      [{ id: 'item-1', heading: 'Item 1', content: 'a' }],
-      [{ id: 'item-1', heading: 'Item 1', content: 'b' }],
-    );
-    const result = diffFilings(oldDoc, newDoc);
-    expect(result.oldFiling.accessionNumber).toBe(oldDoc.filing.accessionNumber);
-    expect(result.newFiling.accessionNumber).toBe(newDoc.filing.accessionNumber);
-    expect('html' in result.oldFiling).toBe(false);
-    expect('html' in result.newFiling).toBe(false);
-  });
-
   it('U-DF-3: generatedAt is a valid Temporal.Instant', () => {
     const { oldDoc, newDoc } = makeDocumentPair([], []);
     const result = diffFilings(oldDoc, newDoc);

--- a/libs/edgar-diff-lib/tests/unit/edgar-network-error.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/edgar-network-error.test.ts
@@ -2,34 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { EdgarNetworkError } from '../../src/client/types.js';
 
 describe('EdgarNetworkError', () => {
-  it('should be instanceof Error', () => {
-    const err = new EdgarNetworkError(429, '0000320193-23-000106');
+  it('EdgarNetworkError: can construct and has correct error type', () => {
+    const err = new EdgarNetworkError(429, '0000320193-23-000106', 5);
     expect(err).toBeInstanceOf(Error);
-  });
-
-  it('should have name "EdgarNetworkError"', () => {
-    const err = new EdgarNetworkError(404, '0000320193-23-000106');
-    expect(err.name).toBe('EdgarNetworkError');
-  });
-
-  it('should include statusCode and accessionNumber in message', () => {
-    const err = new EdgarNetworkError(503, '0000320193-23-000106');
-    expect(err.message).toBe('EDGAR returned 503 for 0000320193-23-000106');
-  });
-
-  it('should store statusCode and accessionNumber as properties', () => {
-    const err = new EdgarNetworkError(429, '0000320193-23-000106');
     expect(err.statusCode).toBe(429);
     expect(err.accessionNumber).toBe('0000320193-23-000106');
-  });
-
-  it('should store optional retryAfter', () => {
-    const err = new EdgarNetworkError(429, '0000320193-23-000106', 5);
     expect(err.retryAfter).toBe(5);
-  });
-
-  it('should have undefined retryAfter when not provided', () => {
-    const err = new EdgarNetworkError(429, '0000320193-23-000106');
-    expect(err.retryAfter).toBeUndefined();
   });
 });

--- a/libs/edgar-diff-lib/tests/unit/grid-normalizer.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/grid-normalizer.test.ts
@@ -95,14 +95,6 @@ describe('normalizeGrid', () => {
     expect(grid.cells[1][2]).toBeNull();
   });
 
-  it('empty table (0 rows) => rowCount=0, colCount=0, empty cells array', () => {
-    const table = makeTable([]);
-    const grid = normalizeGrid(table);
-    expect(grid.rowCount).toBe(0);
-    expect(grid.colCount).toBe(0);
-    expect(grid.cells).toEqual([]);
-  });
-
   it('header-only table normalizes like any other table', () => {
     const table = makeTable([
       makeTableRow([makeTableCell('H1'), makeTableCell('H2')], { isHeader: true }),

--- a/libs/edgar-diff-lib/tests/unit/layout-detector.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/layout-detector.test.ts
@@ -48,16 +48,6 @@ describe('isLayoutTable', () => {
     expect(isLayoutTable(table)).toBe(true);
   });
 
-  it('empty table returns false', () => {
-    const doc = parseDocument(
-      '<table></table>',
-      { withStartIndices: true, withEndIndices: true },
-    );
-    const table = findTable(doc);
-    assertDefined(table);
-    expect(isLayoutTable(table)).toBe(false);
-  });
-
   it('table with non-table elements only returns false', () => {
     const doc = parseDocument(
       '<table><tr><td><div><p>Text</p><span>More</span></div></td></tr></table>',

--- a/libs/edgar-diff-lib/tests/unit/parser.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/parser.test.ts
@@ -543,14 +543,15 @@ describe('error conditions', () => {
     expect(docXml.sections).toHaveLength(0);
   });
 
-  it('E3: truncated/malformed HTML', () => {
-    const htmlTruncated = '<html><body><div><span style="font-weight:700">Item 1. Bus';
-    expect(() => parseFiling(makeRawFiling(htmlTruncated))).not.toThrow();
-  });
-
-  it('E4: HTML with duplicate html tags', () => {
-    const htmlDuplicate = `<html><body><p>First doc</p></body></html>
-<html><body><div><span style="font-weight:700">Item 1. Business</span></div></body></html>`;
-    expect(() => parseFiling(makeRawFiling(htmlDuplicate))).not.toThrow();
+  it('E3: malformed input produces valid StructuredDocument shape without throwing', () => {
+    const inputs = [
+      '<html><body><div><span style="font-weight:700">Item 1. Bus',
+      `<html><body><p>First doc</p></body></html>\n<html><body><div><span style="font-weight:700">Item 1. Business</span></div></body></html>`,
+    ];
+    for (const input of inputs) {
+      const result = parseFiling(makeRawFiling(input));
+      expect(result).toHaveProperty('sections');
+      expect(Array.isArray(result.sections)).toBe(true);
+    }
   });
 });

--- a/libs/edgar-diff-lib/tests/unit/table-extractor.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/table-extractor.test.ts
@@ -109,12 +109,6 @@ describe('extractTable — basic extraction', () => {
     }
   });
 
-  it('empty table produces empty rows array', () => {
-    const { table } = parseTable(`<table></table>`);
-    expect(table).toBeDefined();
-    expect(table.rows).toHaveLength(0);
-  });
-
   it('multiple tables in one section', () => {
     const html = `<html><body>
 <div><span style="font-weight:700">Item 8. Financial Statements</span></div>

--- a/libs/edgar-diff-lib/tests/unit/table-matcher.test.ts
+++ b/libs/edgar-diff-lib/tests/unit/table-matcher.test.ts
@@ -99,13 +99,6 @@ describe('matchTables', () => {
     expect(result.removed).toHaveLength(1);
   });
 
-  it('both empty => matched=[], added=[], removed=[]', () => {
-    const result = matchTables([], []);
-    expect(result.matched).toEqual([]);
-    expect(result.added).toEqual([]);
-    expect(result.removed).toEqual([]);
-  });
-
   it('single table in each list with matching headers => one match', () => {
     const old1 = makeFinancialTable({ headers: ['Revenue', '2023'], rows: [{ label: 'Total', values: ['$100'] }] });
     const new1 = makeFinancialTable({ headers: ['Revenue', '2023'], rows: [{ label: 'Total', values: ['$120'] }] });


### PR DESCRIPTION
## Summary
- Remove ~22 tests that duplicate TypeScript type checking or lack meaningful assertions
- Replace with 2 consolidated tests that verify actual behavior
- Net: 155 lines deleted, 12 added across 9 test files

### Categories removed
| Category | Tests removed | Replacement |
|----------|--------------|-------------|
| EdgarNetworkError constructor | 6 | 1 smoke test |
| diff-types field-existence (DT-U1–U5) | 5 | None (TypeScript enforces) |
| Empty-input boundary tests | 4 | None (trivial guards) |
| "Doesn't throw" tests | 7 | 1 contract test with shape assertion |
| diff-engine shape checks (U-DF-1/U-DF-2) | 2 | None (typed returns) |

Closes #edgar-diff-qbb

## Test plan
- [x] `pnpm nx run-many --target=test` — all tests pass
- [x] `pnpm nx run-many --target=typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)