### PR TITLE
feat: add missing property-based tests (#edgar-diff-ixz)

### DIFF
--- a/libs/edgar-diff-lib/tests/acceptance/accession-number.acceptance.test.ts
+++ b/libs/edgar-diff-lib/tests/acceptance/accession-number.acceptance.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { parseAccessionNumber } from '../../src/client/accession-number.js';
+
+// ============================================================
+// Property-based tests: accession number round-trip invariants
+//
+// Each iteration generates a random valid accession number and
+// verifies round-trip and structural properties.
+// ============================================================
+
+const TEST_COUNT = Number(process.env['ACCESSION_TEST_COUNT'] ?? 200);
+
+function randomDigits(n: number): string {
+  let s = '';
+  for (let i = 0; i < n; i++) {
+    s += Math.floor(Math.random() * 10).toString();
+  }
+  return s;
+}
+
+interface AccessionTestCase {
+  label: string;
+  input: string;
+}
+
+const testCases: AccessionTestCase[] = Array.from({ length: TEST_COUNT }, (_, i) => {
+  const cik = randomDigits(10);
+  const year = randomDigits(2);
+  const seq = randomDigits(6);
+  const input = `${cik}-${year}-${seq}`;
+  return { label: `#${i} ${input}`, input };
+});
+
+describe('property: accession number round-trip invariants', () => {
+  it.each(testCases)(
+    'case $label',
+    ({ input }) => {
+      const parsed = parseAccessionNumber(input);
+
+      // P1: raw round-trips exactly
+      expect(parsed.raw).toBe(input);
+
+      // P2: noDashes equals input with dashes removed
+      expect(parsed.noDashes).toBe(input.replace(/-/g, ''));
+
+      // P3: noDashes is always exactly 18 digits
+      expect(parsed.noDashes).toHaveLength(18);
+      expect(parsed.noDashes).toMatch(/^\d{18}$/);
+
+      // P4: submitterCik is first 10 characters
+      expect(parsed.submitterCik).toBe(input.substring(0, 10));
+      expect(parsed.submitterCik).toMatch(/^\d{10}$/);
+    },
+  );
+});

--- a/libs/edgar-diff-lib/tests/acceptance/heading-normalization.acceptance.test.ts
+++ b/libs/edgar-diff-lib/tests/acceptance/heading-normalization.acceptance.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeHeading,
+  extractItemNumber,
+} from '../../src/parser/section-extractor.js';
+
+// ============================================================
+// Property-based tests: heading normalization invariants
+//
+// Tests idempotency of normalizeHeading and dash-variant
+// equivalence in extractItemNumber across random inputs.
+// ============================================================
+
+const TEST_COUNT = Number(process.env['HEADING_TEST_COUNT'] ?? 200);
+
+// Character pools for generating realistic heading strings
+const EDGE_PUNCT = ['.', ',', ':', ';', '\u2014', '\u2013', '\u2014', '\u2013', '-', ' '];
+const DASH_VARIANTS = ['-', '\u2013', '\u2014']; // hyphen, en-dash, em-dash
+const KNOWN_ITEMS = [
+  '1', '1a', '1b', '1c', '2', '3', '4', '5', '6', '7', '7a', '8',
+  '9', '9a', '9b', '9c', '10', '11', '12', '13', '14', '15', '16',
+];
+
+function randomChoice<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function generateRandomHeading(): string {
+  const parts: string[] = [];
+
+  // Optionally add leading edge punctuation
+  if (Math.random() < 0.4) {
+    const count = Math.floor(Math.random() * 4) + 1;
+    for (let i = 0; i < count; i++) parts.push(randomChoice(EDGE_PUNCT));
+  }
+
+  // Core text: mix of words, spaces, nbsp, punctuation
+  const wordCount = Math.floor(Math.random() * 8) + 1;
+  for (let w = 0; w < wordCount; w++) {
+    if (w > 0) {
+      // Random separator: regular space, multiple spaces, or NBSP
+      const sep = Math.random();
+      if (sep < 0.5) parts.push(' ');
+      else if (sep < 0.7) parts.push('  ');
+      else if (sep < 0.85) parts.push('   ');
+      else parts.push('\u00a0');
+    }
+    // Random word with mixed case
+    const len = Math.floor(Math.random() * 8) + 1;
+    let word = '';
+    for (let c = 0; c < len; c++) {
+      const code = 97 + Math.floor(Math.random() * 26);
+      const ch = String.fromCharCode(code);
+      word += Math.random() < 0.3 ? ch.toUpperCase() : ch;
+    }
+    parts.push(word);
+  }
+
+  // Optionally add trailing edge punctuation
+  if (Math.random() < 0.4) {
+    const count = Math.floor(Math.random() * 4) + 1;
+    for (let i = 0; i < count; i++) parts.push(randomChoice(EDGE_PUNCT));
+  }
+
+  return parts.join('');
+}
+
+// --- Test cases ---
+
+interface IdempotencyCase {
+  label: string;
+  heading: string;
+}
+
+const idempotencyCases: IdempotencyCase[] = Array.from({ length: TEST_COUNT }, (_, i) => {
+  const heading = generateRandomHeading();
+  const preview = heading.length > 40 ? heading.slice(0, 40) + '...' : heading;
+  return { label: `#${i} "${preview}"`, heading };
+});
+
+describe('property: heading normalization idempotency', () => {
+  it.each(idempotencyCases)(
+    'case $label',
+    ({ heading }) => {
+      const once = normalizeHeading(heading);
+      const twice = normalizeHeading(once);
+
+      // P1: normalize(normalize(x)) === normalize(x)
+      expect(twice).toBe(once);
+    },
+  );
+});
+
+// --- Dash-variant equivalence for extractItemNumber ---
+
+interface DashVariantCase {
+  label: string;
+  item: string;
+  prefix: string;
+  suffix: string;
+}
+
+const dashVariantCases: DashVariantCase[] = Array.from({ length: TEST_COUNT }, (_, i) => {
+  const item = randomChoice(KNOWN_ITEMS);
+  const hasPartPrefix = Math.random() < 0.3;
+  const prefix = hasPartPrefix
+    ? `PART ${randomChoice(['I', 'II', 'III', 'IV'])} `
+    : '';
+  const suffix = Math.random() < 0.5
+    ? ` ${randomChoice(['Risk Factors', 'Business', 'Financial Statements', 'MD&A'])}`
+    : '';
+  return { label: `#${i} Item ${item}`, item, prefix, suffix };
+});
+
+describe('property: dash variants collapse to same item number', () => {
+  it.each(dashVariantCases)(
+    'case $label',
+    ({ item, prefix, suffix }) => {
+      const results = DASH_VARIANTS.map(dash => {
+        const heading = `${prefix}Item ${item}${dash}${suffix || ' Details'}`;
+        return extractItemNumber(heading);
+      });
+
+      // P2: All dash variants yield the same non-null item number
+      for (const result of results) {
+        expect(result).toBe(item.toLowerCase());
+      }
+    },
+  );
+});

--- a/libs/edgar-diff-lib/tests/acceptance/rate-limiter.acceptance.test.ts
+++ b/libs/edgar-diff-lib/tests/acceptance/rate-limiter.acceptance.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/client/rate-limiter.js';
+
+// ============================================================
+// Property-based tests: rate limiter throughput invariant
+//
+// For N acquires at rate R tokens/s with capacity C (where N > C),
+// elapsed time >= (N - C) * 1000 / R ms.
+// This tests the fundamental contract of the token bucket.
+// ============================================================
+
+const TEST_COUNT = Number(process.env['RATE_LIMITER_TEST_COUNT'] ?? 50);
+
+interface ThroughputCase {
+  label: string;
+  capacity: number;
+  refillRate: number;
+  totalAcquires: number;
+  expectedMinMs: number;
+}
+
+const throughputCases: ThroughputCase[] = Array.from({ length: TEST_COUNT }, (_, i) => {
+  // Random parameters within reasonable ranges
+  const capacity = Math.floor(Math.random() * 15) + 1;       // 1-15
+  const refillRate = Math.floor(Math.random() * 19) + 2;     // 2-20 tokens/s
+  // N must exceed C so some acquires must wait
+  const extra = Math.floor(Math.random() * 10) + 1;          // 1-10 extra beyond capacity
+  const totalAcquires = capacity + extra;
+  const expectedMinMs = extra * 1000 / refillRate;
+
+  return {
+    label: `#${i} C=${capacity} R=${refillRate}/s N=${totalAcquires} min=${expectedMinMs.toFixed(0)}ms`,
+    capacity,
+    refillRate,
+    totalAcquires,
+    expectedMinMs,
+  };
+});
+
+describe('property: rate limiter throughput invariant', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(throughputCases)(
+    'case $label',
+    async ({ capacity, refillRate, totalAcquires, expectedMinMs }) => {
+      const limiter = new TokenBucketRateLimiter({ capacity, refillRate });
+
+      // Drain the bucket (first C acquires are immediate)
+      for (let i = 0; i < capacity; i++) {
+        await limiter.acquire();
+      }
+
+      // Queue the remaining acquires
+      const extra = totalAcquires - capacity;
+      let resolved = 0;
+      const promises: Promise<void>[] = [];
+      for (let i = 0; i < extra; i++) {
+        promises.push(limiter.acquire().then(() => { resolved++; }));
+      }
+
+      // None should have resolved yet (bucket was drained)
+      expect(resolved).toBe(0);
+
+      // Advance to just before the theoretical minimum — not all should be done
+      // Use a small epsilon to account for timer interval granularity
+      const intervalMs = Math.ceil(1000 / refillRate);
+      const justBefore = expectedMinMs - intervalMs;
+      if (justBefore > 0) {
+        await vi.advanceTimersByTimeAsync(justBefore);
+        expect(resolved).toBeLessThan(extra);
+      }
+
+      // Advance well past the minimum — all should resolve
+      // Add enough buffer for timer granularity (one extra interval per acquire)
+      const buffer = extra * intervalMs;
+      await vi.advanceTimersByTimeAsync(expectedMinMs + buffer);
+      expect(resolved).toBe(extra);
+
+      await Promise.all(promises);
+      limiter.dispose();
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- **Accession number round-trip** (200 cases): verifies `parse(x).raw === x`, `noDashes === x.replace(/-/g, '')`, and `noDashes` is always exactly 18 digits
- **Heading normalization idempotency** (200 cases): verifies `normalize(normalize(x)) === normalize(x)` for random headings, plus all unicode dash variants (em-dash, en-dash, hyphen) extract to the same item number (200 cases)
- **Rate limiter throughput invariant** (50 cases): for random (C, R, N) parameters, verifies elapsed time >= (N - C) * 1000 / R ms using fake timers

## Test plan
- [x] All 650 new property-based tests pass
- [x] Full test suite passes (5528 tests, 38 files)
- [x] Typecheck clean
- [x] Lint clean (0 errors, only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)