### PR TITLE
Design: US-2.9 Filing Selectors

### DIFF
--- a/.specs/us-2-9-filing-selectors/implementation-design.md
+++ b/.specs/us-2-9-filing-selectors/implementation-design.md
@@ -1,0 +1,619 @@
+# US-2.9: Filing Selectors — Implementation Design
+
+## Overview
+
+After a company is selected (US-2.8), both Filing A and Filing B panels show dropdown selectors populated with the company's available filings. Each dropdown lists filings with form type and filing date, filtered to supported types (10-K, 10-K/A, 10-Q, 10-Q/A), sorted by date descending. Selecting a filing fires a callback consumed by US-2.10.
+
+---
+
+## Approach
+
+The existing `fetchCompanySubmissions` in `sec-submissions.ts` already hits `/api/sec/submissions/CIK{cik}.json` but currently discards the `filings.recent` data. We extend the submissions service to also extract and return the filing list, then build a hook and component to surface it in the UI.
+
+**Strategy:**
+
+1. **Extend the submissions service** — Add a `fetchFilingList` function that parses `filings.recent` parallel arrays, filters to supported form types, and sorts by date descending
+2. **Add a React hook** (`useFilingList`) — Calls the service when `selectedCompany` changes, manages loading/error/data states with abort-on-reselect
+3. **Build a FilingSelector component** — A `<select>` dropdown that renders the filing list and fires `onSelect`
+4. **Wire into FilingPanel** — Replace the disabled `<select>` placeholder with FilingSelector
+5. **Wire into App** — Pass `selectedCompany` through to trigger filing list fetch, pass filing list + selection state to each FilingPanel
+
+**What's NOT in scope:**
+- Fetching filing HTML content (US-2.10)
+- Error handling beyond basic fetch failures (US-2.10)
+- Fiscal period display (US-2.12 — SEC API doesn't provide it)
+- Pagination of filings beyond `filings.recent` (MVP constraint)
+
+---
+
+## Files to Create/Modify
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/src/services/filing-list.ts` | Parse submissions response `filings.recent` parallel arrays into `AvailableFiling[]`, filter to supported form types, sort by date descending |
+| `apps/web/src/services/filing-list.test.ts` | Unit tests for parsing, filtering, sorting, and edge cases |
+| `apps/web/src/hooks/useFilingList.ts` | React hook: fetches filing list when company changes, manages loading/error/data, aborts on company change |
+| `apps/web/src/hooks/useFilingList.test.ts` | Hook tests: state transitions, abort-on-reselect, error handling |
+| `apps/web/src/components/FilingSelector.tsx` | Dropdown `<select>` component rendering the filing list |
+| `apps/web/src/components/FilingSelector.test.tsx` | Component tests: renders options, fires onSelect, disabled states |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `apps/web/src/services/types.ts` | Add `AvailableFiling` type and `FilingListStatus` |
+| `apps/web/src/services/sec-submissions.ts` | Widen `SubmissionsResponse` to include `filings.recent` arrays; optionally export the raw response type for `filing-list.ts` |
+| `apps/web/src/components/FilingPanel.tsx` | Accept optional `filings`, `selectedFiling`, `onFilingSelect` props; render `FilingSelector` instead of disabled `<select>` |
+| `apps/web/src/components/FilingPanel.test.tsx` | Add tests for filing selector rendering and interaction |
+| `apps/web/src/App.tsx` | Wire `selectedCompany` → `useFilingList` → pass filings to each FilingPanel; add `selectedFilingA`/`selectedFilingB` state |
+| `apps/web/src/test-fixtures/company-search-fixtures.ts` | Expand `MOCK_AAPL_SUBMISSIONS` and `MOCK_MSFT_SUBMISSIONS` with multiple filings of different types for testing |
+
+---
+
+## Interfaces and Types
+
+### `AvailableFiling` (in `services/types.ts`)
+
+```typescript
+/** A filing available for selection in the dropdown. */
+export interface AvailableFiling {
+  /** SEC accession number (e.g., "0000320193-23-000106") */
+  accessionNumber: string;
+  /** Form type (e.g., "10-K", "10-Q/A") */
+  formType: string;
+  /** Filing date as ISO string (e.g., "2023-11-03") */
+  filingDate: string;
+}
+```
+
+**Design note:** `filingDate` is kept as an ISO string rather than `Temporal.PlainDate` because:
+- It comes from the SEC API as a string
+- It's used as a display value and for sorting (ISO strings sort correctly)
+- Avoids the `@js-temporal/polyfill` dependency in the web app's service layer
+- The dropdown label is built with simple string formatting
+
+### `FilingListStatus` (in `services/types.ts`)
+
+```typescript
+/** States the filing list fetch can be in. */
+export type FilingListStatus = 'idle' | 'loading' | 'loaded' | 'error';
+```
+
+### `fetchFilingList` (in `services/filing-list.ts`)
+
+```typescript
+import type { AvailableFiling } from './types';
+
+/** Supported form types for the filing selector. */
+export const SUPPORTED_FORM_TYPES = ['10-K', '10-K/A', '10-Q', '10-Q/A'] as const;
+
+/**
+ * Fetch and parse available filings for a company.
+ * Hits the same submissions endpoint as fetchCompanySubmissions,
+ * but extracts the filings.recent parallel arrays.
+ */
+export async function fetchFilingList(
+  cik: string,
+  signal?: AbortSignal,
+): Promise<AvailableFiling[]>;
+```
+
+### `useFilingList` hook (in `hooks/useFilingList.ts`)
+
+```typescript
+import type { Company } from '../services/types';
+import type { AvailableFiling } from '../services/types';
+import type { FilingListStatus } from '../services/types';
+
+export interface UseFilingListReturn {
+  /** Available filings for the selected company */
+  filings: AvailableFiling[];
+  /** Current fetch status */
+  status: FilingListStatus;
+  /** Error message, if any */
+  error: string | null;
+}
+
+export function useFilingList(company: Company | null): UseFilingListReturn;
+```
+
+### `FilingSelector` component (in `components/FilingSelector.tsx`)
+
+```typescript
+import type { AvailableFiling } from '../services/types';
+
+interface FilingSelectorProps {
+  /** Available filings to show in the dropdown */
+  filings: AvailableFiling[];
+  /** Currently selected filing (by accession number) */
+  selectedAccession: string | null;
+  /** Called when user selects a filing */
+  onSelect: (filing: AvailableFiling) => void;
+  /** Disabled when no filings are available or still loading */
+  disabled?: boolean;
+  /** Accessible label (e.g., "Select Filing A") */
+  'aria-label': string;
+}
+
+export function FilingSelector(props: FilingSelectorProps): JSX.Element;
+```
+
+### Updated `FilingPanel` props
+
+```typescript
+interface FilingPanelProps {
+  label: string;
+  document?: StructuredDocument;
+  sectionDiffs?: SectionDiff[];
+  side?: Side;
+  // New props for US-2.9:
+  filings?: AvailableFiling[];
+  selectedFiling?: string | null;
+  onFilingSelect?: (filing: AvailableFiling) => void;
+  filingListStatus?: FilingListStatus;
+}
+```
+
+---
+
+## Data Flow
+
+```
+User selects company in SearchBar (US-2.8)
+       │
+       ▼
+App.selectedCompany state updates
+       │
+       ▼
+useFilingList(selectedCompany) hook fires
+       │
+       ├─ company is null → status='idle', filings=[]
+       │
+       └─ company is set → status='loading'
+              │
+              ▼
+        fetchFilingList(company.cik, signal)
+              │
+              ├─ GET /api/sec/submissions/CIK{cik}.json
+              │   (same endpoint as US-2.8, but we parse filings.recent)
+              │
+              ├─ Parse parallel arrays:
+              │   accessionNumber[i], filingDate[i], form[i]
+              │   → AvailableFiling[]
+              │
+              ├─ Filter: only SUPPORTED_FORM_TYPES
+              │
+              ├─ Sort: by filingDate descending
+              │
+              ├─ Success → status='loaded', filings=[...]
+              │
+              └─ Failure → status='error', error message
+              │
+              ▼
+App passes filings to both FilingPanels
+              │
+              ▼
+FilingPanel renders FilingSelector
+              │
+              ├─ No filings → disabled <select> "Select a filing..."
+              │
+              └─ Has filings → enabled <select> with options
+                     │
+                     ▼
+              User selects a filing from dropdown
+                     │
+                     ▼
+              onFilingSelect(filing) → App.selectedFilingA or B state
+                     │
+                     ▼
+              (US-2.10 will consume selectedFilingA + selectedFilingB
+               to trigger the diff pipeline)
+```
+
+### Filing Label Format
+
+Each `<option>` displays: `"10-K | 2023-11-03"` (form type + filing date).
+
+Fiscal period display (e.g., "(FY 2021)") is deferred to US-2.12 since the SEC submissions API doesn't provide it. Adding it later requires either XBRL parsing or a separate API call — out of scope for MVP.
+
+---
+
+## Service Layer: `filing-list.ts`
+
+### Parsing Strategy
+
+The SEC submissions API returns `filings.recent` as **parallel arrays** (not an array of objects):
+
+```json
+{
+  "filings": {
+    "recent": {
+      "accessionNumber": ["0000320193-23-000106", "0000320193-23-000077", ...],
+      "filingDate": ["2023-11-03", "2023-08-04", ...],
+      "form": ["10-K", "10-Q", ...]
+    }
+  }
+}
+```
+
+The service zips these into `AvailableFiling[]`, filters, and sorts:
+
+```typescript
+export async function fetchFilingList(
+  cik: string,
+  signal?: AbortSignal,
+): Promise<AvailableFiling[]> {
+  const paddedCik = cik.replace(/^0+/, '').padStart(10, '0');
+  const url = `/api/sec/submissions/CIK${paddedCik}.json`;
+
+  const response = await fetch(url, { signal: signal ?? AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    throw new Error('Unable to load filings. Try again shortly.');
+  }
+
+  const data = await response.json();
+  const recent = data?.filings?.recent;
+  if (!recent) return [];
+
+  const { accessionNumber = [], filingDate = [], form = [] } = recent;
+  const len = Math.min(accessionNumber.length, filingDate.length, form.length);
+
+  const filings: AvailableFiling[] = [];
+  for (let i = 0; i < len; i++) {
+    if (SUPPORTED_FORM_TYPES.includes(form[i])) {
+      filings.push({
+        accessionNumber: accessionNumber[i],
+        formType: form[i],
+        filingDate: filingDate[i],
+      });
+    }
+  }
+
+  // Already date-descending from SEC, but sort explicitly to guarantee
+  filings.sort((a, b) => b.filingDate.localeCompare(a.filingDate));
+
+  return filings;
+}
+```
+
+### Why a Separate Function (Not Extending `fetchCompanySubmissions`)
+
+- **Single Responsibility:** `fetchCompanySubmissions` returns `Company` (identity). `fetchFilingList` returns `AvailableFiling[]` (filing metadata). Different consumers, different shapes.
+- **Independent Caching:** US-2.10 may cache filings differently from company identity.
+- **Testability:** Each function has a focused test suite.
+
+### Duplicate Fetch Concern
+
+Both `fetchCompanySubmissions` (US-2.8) and `fetchFilingList` hit the same endpoint. This means two requests for the same CIK on company selection. This is acceptable for MVP because:
+- The response is cached by the Cloudflare Worker (or browser HTTP cache)
+- The second request should be a cache hit
+- Merging them would couple the company search flow to the filing list flow
+
+If this becomes a performance concern, a shared cache layer can be added in US-2.10.
+
+---
+
+## Hook: `useFilingList`
+
+Follows the same patterns as `useCompanySearch`:
+
+```typescript
+export function useFilingList(company: Company | null): UseFilingListReturn {
+  const [filings, setFilings] = useState<AvailableFiling[]>([]);
+  const [status, setStatus] = useState<FilingListStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    // Reset when company changes or clears
+    setFilings([]);
+    setError(null);
+
+    if (!company) {
+      setStatus('idle');
+      return;
+    }
+
+    // Abort previous in-flight request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus('loading');
+
+    fetchFilingList(company.cik, controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) {
+          setFilings(result);
+          setStatus('loaded');
+        }
+      },
+      (err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        if (!controller.signal.aborted) {
+          setStatus('error');
+          setError(err instanceof Error ? err.message : 'Failed to load filings');
+        }
+      },
+    );
+
+    return () => {
+      controller.abort();
+    };
+  }, [company]);
+
+  return { filings, status, error };
+}
+```
+
+**Key behaviors:**
+- Fires on `company` change (effect dependency)
+- Aborts in-flight request when company changes (abort controller)
+- Resets state when company is null (cleared)
+- Ignores AbortError silently (same pattern as `useCompanySearch`)
+
+---
+
+## Component: `FilingSelector`
+
+A thin wrapper around a native `<select>` element:
+
+```typescript
+export function FilingSelector({
+  filings,
+  selectedAccession,
+  onSelect,
+  disabled,
+  'aria-label': ariaLabel,
+}: FilingSelectorProps) {
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const filing = filings.find((f) => f.accessionNumber === e.target.value);
+    if (filing) onSelect(filing);
+  }
+
+  return (
+    <select
+      value={selectedAccession ?? ''}
+      onChange={handleChange}
+      disabled={disabled || filings.length === 0}
+      aria-label={ariaLabel}
+      className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm
+                 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed
+                 bg-white text-gray-900"
+    >
+      <option value="">Select a filing...</option>
+      {filings.map((f) => (
+        <option key={f.accessionNumber} value={f.accessionNumber}>
+          {f.formType} | {f.filingDate}
+        </option>
+      ))}
+    </select>
+  );
+}
+```
+
+**Why native `<select>` over a custom dropdown:**
+- Keyboard-accessible by default (no custom aria work)
+- Mobile-friendly (native OS picker)
+- Filing list is small (typically <20 entries) — no virtualization needed
+- Matches the existing disabled `<select>` already in FilingPanel
+
+---
+
+## App Wiring
+
+### `App.tsx` Changes
+
+```typescript
+export function App() {
+  const [selectedCompany, setSelectedCompany] = useState<Company | null>(null);
+  const { filings, status: filingListStatus } = useFilingList(selectedCompany);
+  const [selectedFilingA, setSelectedFilingA] = useState<AvailableFiling | null>(null);
+  const [selectedFilingB, setSelectedFilingB] = useState<AvailableFiling | null>(null);
+
+  // Reset filing selections when company changes
+  useEffect(() => {
+    setSelectedFilingA(null);
+    setSelectedFilingB(null);
+  }, [selectedCompany]);
+
+  // ... existing sampleDiffs/sections/refs/handlers ...
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-50">
+      <Header />
+      <SearchBar onCompanySelect={setSelectedCompany} />
+      <main className="flex-1 flex overflow-hidden">
+        <SectionNav ... />
+        <FilingPanel
+          ref={oldPanelRef}
+          label="Filing A"
+          document={sampleDocument}
+          sectionDiffs={sampleDiffs}
+          side="old"
+          filings={filings}
+          selectedFiling={selectedFilingA?.accessionNumber ?? null}
+          onFilingSelect={setSelectedFilingA}
+          filingListStatus={filingListStatus}
+        />
+        <div className="w-px bg-gray-200" aria-hidden="true" />
+        <FilingPanel
+          ref={newPanelRef}
+          label="Filing B"
+          document={sampleDocument}
+          sectionDiffs={sampleDiffs}
+          side="new"
+          filings={filings}
+          selectedFiling={selectedFilingB?.accessionNumber ?? null}
+          onFilingSelect={setSelectedFilingB}
+          filingListStatus={filingListStatus}
+        />
+      </main>
+    </div>
+  );
+}
+```
+
+**Key decisions:**
+- Both panels share the same `filings` list (both are from the same company)
+- Each panel has independent selection state (`selectedFilingA`, `selectedFilingB`)
+- Filing selections reset when company changes
+- `selectedFilingA`/`selectedFilingB` are ready for US-2.10 to consume
+
+### `FilingPanel.tsx` Changes
+
+Replace the disabled `<select>` with `FilingSelector`:
+
+```typescript
+export const FilingPanel = forwardRef<HTMLDivElement, FilingPanelProps>(
+  function FilingPanel({ label, document, sectionDiffs, side, filings, selectedFiling, onFilingSelect, filingListStatus }, ref) {
+    return (
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        <div className="shrink-0 px-4 py-3 border-b border-gray-200 bg-white">
+          <h2 className="text-sm font-semibold text-gray-900 mb-2">{label}</h2>
+          {filings && onFilingSelect ? (
+            <FilingSelector
+              filings={filings}
+              selectedAccession={selectedFiling ?? null}
+              onSelect={onFilingSelect}
+              disabled={filingListStatus === 'loading'}
+              aria-label={`Select ${label}`}
+            />
+          ) : (
+            <select disabled className="w-full px-3 py-1.5 border border-gray-300 rounded-md bg-gray-50 text-gray-500 text-sm cursor-not-allowed">
+              <option>Select a filing...</option>
+            </select>
+          )}
+        </div>
+        {/* ... content area unchanged ... */}
+      </div>
+    );
+  }
+);
+```
+
+**Backward compatibility:** When `filings`/`onFilingSelect` are not provided, the disabled placeholder renders (matching current behavior). This keeps all existing tests passing without modification.
+
+---
+
+## Test Fixtures
+
+### Expanded `MOCK_AAPL_SUBMISSIONS`
+
+The existing fixture has a single filing. Expand it with multiple filings of different types for comprehensive testing:
+
+```typescript
+export const MOCK_AAPL_SUBMISSIONS = {
+  cik: '320193',
+  name: 'Apple Inc.',
+  tickers: ['AAPL'],
+  exchanges: ['Nasdaq'],
+  filings: {
+    recent: {
+      accessionNumber: [
+        '0000320193-23-000106',
+        '0000320193-23-000077',
+        '0000320193-23-000064',
+        '0000320193-22-000108',
+        '0000320193-23-000050',  // 8-K (should be filtered out)
+      ],
+      filingDate: [
+        '2023-11-03',
+        '2023-08-04',
+        '2023-05-05',
+        '2022-10-28',
+        '2023-09-15',
+      ],
+      form: [
+        '10-K',
+        '10-Q',
+        '10-Q',
+        '10-K',
+        '8-K',  // unsupported — should be filtered out
+      ],
+    },
+  },
+};
+```
+
+### Additional Test Fixture
+
+```typescript
+/** Company with no supported filings (only 8-K) */
+export const MOCK_NO_SUPPORTED_FILINGS = {
+  cik: '999999',
+  name: 'Only 8K Corp',
+  tickers: ['ONLY8K'],
+  exchanges: ['NYSE'],
+  filings: {
+    recent: {
+      accessionNumber: ['0000999999-23-000001'],
+      filingDate: ['2023-06-15'],
+      form: ['8-K'],
+    },
+  },
+};
+```
+
+---
+
+## Dependencies
+
+### Existing (no new dependencies)
+
+- React 19 hooks (`useState`, `useEffect`, `useRef`, `useCallback`)
+- Native `fetch` API (via Worker proxy)
+- Vitest + `@testing-library/react` + `@testing-library/user-event`
+- Existing `services/types.ts` types
+
+### Internal Imports
+
+- `services/filing-list.ts` → imports from `services/types.ts`
+- `hooks/useFilingList.ts` → imports from `services/filing-list.ts`, `services/types.ts`
+- `components/FilingSelector.tsx` → imports from `services/types.ts`
+- `components/FilingPanel.tsx` → imports `FilingSelector`, types from `services/types.ts`
+- `App.tsx` → imports `useFilingList` hook
+
+---
+
+## Edge Cases
+
+### Data Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Company with no supported filings (only 8-K, DEF 14A, etc.) | Dropdown shows "Select a filing..." and is disabled. `filings` array is empty. |
+| Company with empty `filings.recent` | Same as above — empty array, disabled dropdown. |
+| `filings.recent` missing from response | `fetchFilingList` returns `[]`. No error — treat as company with no filings. |
+| Parallel arrays of different lengths | Use `Math.min` of all array lengths to avoid index-out-of-bounds. |
+| Duplicate accession numbers | Pass through — SEC data shouldn't have duplicates, but `<option key>` handles it. |
+
+### Interaction Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Company changes while filing list is loading | Abort in-flight request via AbortController. Reset filings and selections. |
+| Company cleared (search cleared) | `company=null` → reset to idle, empty filings, clear selections. |
+| User selects same filing in both A and B | Allowed — comparing a filing to itself is a valid (if unusual) action. |
+| Filing selected, then company changes | Both `selectedFilingA` and `selectedFilingB` reset to null via the `useEffect` in App. |
+
+### Network Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Fetch fails (network error, 500, etc.) | `status='error'`, user-friendly message. Dropdown stays disabled. |
+| Fetch returns 404 | "Unable to load filings. Try again shortly." |
+| Fetch returns 429 (rate limited) | Same error message. No retry logic in US-2.9 scope. |
+| AbortError (from company change) | Silently ignored (same pattern as `useCompanySearch`). |
+
+---
+
+## Open Questions
+
+1. **Caching the submissions response:** Both `fetchCompanySubmissions` (US-2.8) and `fetchFilingList` (US-2.9) hit the same endpoint. Should we share a response cache? **Tentative answer:** No for MVP. The Worker/browser HTTP cache handles deduplication. A shared in-memory cache can be added in US-2.10 if needed.
+
+2. **Loading indicator in dropdown:** Should we show "Loading filings..." text in the dropdown while fetching? **Tentative answer:** The dropdown is disabled during loading. A loading spinner or text next to the dropdown could be added in US-2.12 polish.
+
+3. **Default selection:** Should the most recent filing auto-select for Filing A and the second-most-recent for Filing B? **Tentative answer:** No — require explicit user selection. Auto-selection would trigger the diff pipeline (US-2.10) without user intent. Can revisit in polish.

--- a/.specs/us-2-9-filing-selectors/test-plan.md
+++ b/.specs/us-2-9-filing-selectors/test-plan.md
@@ -1,0 +1,609 @@
+# US-2.9: Filing Selectors — Test Plan
+
+## Overview
+
+This test plan covers the Filing Selectors feature, which enables filing dropdown selectors in both Filing A and Filing B panels after a company is selected (US-2.8). Each dropdown lists available filings filtered to supported form types (10-K, 10-K/A, 10-Q, 10-Q/A), sorted by filing date descending (most recent first).
+
+The architecture follows the same service → hook → component pattern established by US-2.8:
+
+1. **Service layer (`filing-list.ts`):** Fetches SEC submissions for a CIK via Worker proxy, parses parallel arrays into `AvailableFiling` objects, filters to supported form types, sorts by date descending.
+2. **Hook (`useFilingList.ts`):** Wraps the service, manages loading/error state, handles abort on company change.
+3. **Component (`FilingSelector.tsx`):** Renders a `<select>` dropdown with filing options, fires `onSelect` callback when a filing is chosen.
+4. **Integration:** `App` calls `useFilingList(selectedCompany)` and passes `filings`, `selectedFiling`, `onFilingSelect`, `filingListStatus` props to each `FilingPanel`. `FilingPanel` renders `FilingSelector` when these props are provided, falling back to the disabled `<select>` placeholder otherwise.
+
+**Test file locations:**
+- `apps/web/src/services/filing-list.test.ts` — Parse, filter, sort filings from SEC submissions
+- `apps/web/src/hooks/useFilingList.test.ts` — Hook state transitions, abort, error handling
+- `apps/web/src/components/FilingSelector.test.tsx` — Component rendering, interaction, ARIA, callbacks
+- `apps/web/src/components/FilingPanel.test.tsx` — Integration additions (selector wiring)
+- `apps/web/src/App.test.tsx` — App-level integration (company → filings flow)
+
+**Test stack:** Vitest + React Testing Library (jsdom), following existing patterns in `SearchBar.test.tsx` and `useCompanySearch.test.ts`.
+
+---
+
+## 1. BDD Acceptance Criteria (Given/When/Then)
+
+### AC-1: Filing selectors appear after company selection
+
+```gherkin
+Given both Filing A and Filing B panels are displayed with disabled selectors
+When the user selects a company via the SearchBar (e.g., "AAPL")
+Then both filing dropdowns become enabled
+And each dropdown lists available filings for that company
+```
+
+### AC-2: Filing list shows form type and filing date
+
+```gherkin
+Given a company with multiple filings is selected
+When the filing dropdown is opened
+Then each option displays the form type and filing date
+  (e.g., "10-K | 2023-11-03")
+And options are sorted by filing date, most recent first
+```
+
+### AC-3: Only supported form types are shown
+
+```gherkin
+Given a company has filings of types 10-K, 10-Q, 8-K, S-1, DEF 14A
+When the filing list is loaded
+Then only 10-K, 10-K/A, 10-Q, and 10-Q/A filings appear in the dropdown
+And 8-K, S-1, DEF 14A, and other unsupported types are excluded
+```
+
+### AC-4: Filing A and Filing B are independent selectors
+
+```gherkin
+Given both filing selectors are populated with the same list of filings
+When the user selects "10-K | 2023-11-03" in Filing A
+And selects "10-Q | 2023-08-04" in Filing B
+Then each selector retains its own selection independently
+And neither selection affects the other
+```
+
+### AC-5: Selecting a filing triggers callback
+
+```gherkin
+Given a filing selector is populated and enabled
+When the user selects a filing from the dropdown
+Then the onSelect callback fires with the filing metadata
+  (accession number, form type, filing date)
+```
+
+### AC-6: Selectors disable when no company is selected
+
+```gherkin
+Given no company is selected (initial state or after clearing search)
+When the user views the filing panels
+Then both filing selectors are disabled
+And each shows placeholder text "Select a filing..."
+```
+
+### AC-7: Company change reloads filing list
+
+```gherkin
+Given "Apple Inc." is selected and filing selectors are populated
+When the user clears the search and selects "Microsoft Corporation"
+Then the previous filing selections are cleared
+And both selectors reload with Microsoft's filings
+```
+
+### AC-8: Empty result after filtering
+
+```gherkin
+Given a company has only 8-K filings (no supported form types)
+When the filing list is loaded and filtered
+Then the dropdown shows no options (or a "No supported filings" message)
+And the selector remains disabled or shows empty state
+```
+
+---
+
+## 2. Unit Tests
+
+### 2.1 Filing List Service (`filing-list.test.ts`)
+
+Parses SEC submissions response parallel arrays into structured filing objects, filters to supported types, and sorts by date.
+
+#### Parsing Parallel Arrays
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Parses single filing from parallel arrays | `{ accessionNumber: ['0000320193-23-000106'], filingDate: ['2023-11-03'], form: ['10-K'] }` | `[{ accessionNumber: '0000320193-23-000106', filingDate: '2023-11-03', formType: '10-K' }]` |
+| Parses multiple filings | 3 entries across arrays | 3 `AvailableFiling` objects |
+| Handles mismatched array lengths gracefully | `accessionNumber` has 3, `form` has 2 | Uses shortest length (no crash) |
+
+#### Filtering to Supported Form Types
+
+| Test | Input Form Types | Expected |
+|------|-----------------|----------|
+| Keeps 10-K | `['10-K']` | 1 filing |
+| Keeps 10-K/A | `['10-K/A']` | 1 filing |
+| Keeps 10-Q | `['10-Q']` | 1 filing |
+| Keeps 10-Q/A | `['10-Q/A']` | 1 filing |
+| Removes 8-K | `['8-K']` | 0 filings |
+| Removes S-1 | `['S-1']` | 0 filings |
+| Removes DEF 14A | `['DEF 14A']` | 0 filings |
+| Mixed: keeps supported, removes others | `['10-K', '8-K', '10-Q', 'S-1', 'DEF 14A']` | 2 filings (10-K, 10-Q) |
+| All unsupported → empty result | `['8-K', '8-K/A', 'S-1', 'DEF 14A']` | `[]` |
+
+#### Sorting by Date Descending
+
+| Test | Input Dates | Expected Order |
+|------|------------|----------------|
+| Already sorted → no change | `['2023-11-03', '2023-08-04', '2023-02-03']` | Same |
+| Unsorted → sorted descending | `['2023-02-03', '2023-11-03', '2023-08-04']` | `['2023-11-03', '2023-08-04', '2023-02-03']` |
+| Same date → stable order | `['2023-11-03', '2023-11-03']` | Both present, original order preserved |
+
+#### Edge Cases
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Empty arrays | `{ accessionNumber: [], filingDate: [], form: [] }` | `[]` |
+| All entries filtered out | Only `8-K` filings | `[]` |
+| Single filing passes through | 1 supported filing | `[filing]` |
+| Large input (50+ filings) | 50 mixed filings | Only supported types, sorted |
+
+### 2.2 `useFilingList` Hook (`useFilingList.test.ts`)
+
+Wraps the filing list service. Mock the `filing-list` service module. Use `renderHook` from `@testing-library/react`.
+
+#### State Shape & Transitions
+
+| Test | Action | Expected State |
+|------|--------|----------------|
+| Initial state (no company) | Hook renders with `company = null` | `{ filings: [], status: 'idle', error: null }` |
+| Company provided → loading | Set `company = { cik: '0000320193', ... }` | `{ filings: [], status: 'loading', error: null }` |
+| Fetch succeeds → filings populated | Service resolves with filings | `{ filings: [...], status: 'loaded', error: null }` |
+| Fetch fails → error | Service rejects | `{ filings: [], status: 'error', error: 'Failed to load filings' }` |
+| Company cleared → reset | Set `company = null` | `{ filings: [], status: 'idle', error: null }` |
+| Company changes → reload | Change from AAPL to MSFT | Previous filings cleared, new filings fetched |
+
+#### Concurrency & Cleanup
+
+| Test | Action | Expected |
+|------|--------|----------|
+| Aborts in-flight fetch on company change | Select AAPL, then MSFT before AAPL resolves | Only MSFT filings displayed |
+| Aborts in-flight fetch on company clear | Select AAPL, then clear | No stale filings |
+| No state update after unmount | Select company, then unmount | No React warnings |
+| AbortError not treated as error | Abort during fetch | Status not set to 'error' |
+
+### 2.3 FilingSelector Component (`FilingSelector.test.tsx`)
+
+`FilingSelector` is a **pure presentational component** — it receives props directly, no hook mocking needed. Test by rendering with different prop combinations.
+
+#### Test Setup
+
+```typescript
+import type { AvailableFiling } from '../services/types';
+
+const sampleFilings: AvailableFiling[] = [
+  { accessionNumber: '0000320193-23-000106', formType: '10-K', filingDate: '2023-11-03' },
+  { accessionNumber: '0000320193-23-000077', formType: '10-Q', filingDate: '2023-08-04' },
+  { accessionNumber: '0000320193-23-000064', formType: '10-Q', filingDate: '2023-05-05' },
+];
+
+const defaultProps: FilingSelectorProps = {
+  filings: [],
+  selectedAccession: null,
+  onSelect: vi.fn(),
+  disabled: false,
+  'aria-label': 'Select Filing A',
+};
+```
+
+#### Rendering
+
+| Test | Props | Expected |
+|------|-------|----------|
+| Renders a select element | Default props | `<select>` present |
+| Disabled when no filings | `filings: []` | Select is disabled (component disables when `filings.length === 0`) |
+| Disabled when `disabled` prop is true | `disabled: true, filings: sampleFilings` | Select is disabled |
+| Enabled when filings provided and not disabled | `filings: sampleFilings` | Select is enabled |
+| Shows placeholder option | Default | First option is "Select a filing..." with empty value |
+| Renders filing options | `filings: sampleFilings` | 3 `<option>` elements (plus placeholder) |
+| Option text shows form type and date | Filing: `{ formType: '10-K', filingDate: '2023-11-03' }` | Option text: `"10-K | 2023-11-03"` |
+| Option value is accession number | `filings: sampleFilings` | Each `<option>` has `value={accessionNumber}` |
+| Options render in provided order | `filings: sampleFilings` | DOM order matches array order (service pre-sorts) |
+
+#### Interaction
+
+| Test | Action | Expected |
+|------|--------|----------|
+| Calls onSelect with filing data on change | `userEvent.selectOptions(select, accessionNumber)` | `onSelect` called with matching `AvailableFiling` object |
+| Does not call onSelect for placeholder | Select the empty-value placeholder option | `onSelect` not called |
+| Reflects selectedAccession in value | `selectedAccession: '0000320193-23-000106'` | Select element value matches |
+| Resets to placeholder when selectedAccession is null | `selectedAccession: null` | Select shows placeholder |
+
+#### Accessibility
+
+| Test | Props | Expected |
+|------|-------|----------|
+| Has aria-label | `aria-label: 'Select Filing A'` | `<select>` has `aria-label="Select Filing A"` |
+| Disabled state is accessible | `disabled: true` | `<select>` has `disabled` attribute |
+| Options are selectable via keyboard | Standard props + filings | Native `<select>` keyboard behavior works |
+
+---
+
+## 3. Integration Tests
+
+### 3.1 FilingPanel + FilingSelector Integration
+
+Additions to `FilingPanel.test.tsx`. Verify that FilingPanel renders FilingSelector when filing props are provided, and falls back to the disabled placeholder otherwise.
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| FilingPanel renders FilingSelector when filings prop provided | Render with `filings`, `onFilingSelect` props | FilingSelector component present with options |
+| FilingPanel without filing props shows disabled placeholder | No `filings`/`onFilingSelect` props (backward compat) | Disabled `<select>` with "Select a filing..." |
+| FilingPanel with empty filings shows disabled selector | `filings: []` | FilingSelector present but disabled |
+| FilingPanel passes aria-label based on label | `label="Filing A"` | FilingSelector has `aria-label="Select Filing A"` |
+| FilingPanel disabled during loading | `filingListStatus: 'loading'` | FilingSelector is disabled |
+| onFilingSelect callback wired through | Select a filing in FilingSelector | Parent `onFilingSelect` callback receives filing data |
+
+### 3.2 App-Level Integration (`App.test.tsx`)
+
+Verify that company selection flows through to filing selectors. Mock fetch at the boundary.
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| Filing selectors disabled on initial load | Render App | Both selectors disabled |
+| Company selection enables filing selectors | Search + select AAPL | Both selectors populated with AAPL filings |
+| Company clear disables filing selectors | Select AAPL, then clear search | Both selectors revert to disabled |
+| Both panels receive independent filing selection | Select different filings in A and B | Each panel's selection callback fires independently |
+
+### 3.3 Full Flow — Company to Filing Selection (mocked fetch)
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| Type → select company → filings load → select filing | Full interaction flow | Filing callback fires with correct data |
+| Type → select company → filings load → select different filings in A and B | Full interaction flow | Independent selections, independent callbacks |
+| Type → select company → filings load → clear search → selectors disabled | Full interaction with clear | Clean state reset |
+
+---
+
+## 4. End-to-End Scenarios
+
+Full user journeys. In Vitest: integration tests with mocked fetch. In UAT: against the running dev server with real SEC data.
+
+### E2E-1: Successful filing selection
+
+1. User opens the app
+2. Both filing selectors are disabled with "Select a filing..." placeholder
+3. User searches "AAPL" and selects Apple Inc.
+4. Both filing selectors become enabled
+5. Each dropdown lists Apple's supported filings (10-K, 10-Q entries)
+6. User selects "10-K | 2023-11-03" in Filing A
+7. Selection is retained and callback fires
+
+### E2E-2: Independent filing selections
+
+1. User selects Apple Inc. via search
+2. Selects "10-K | 2023-11-03" in Filing A
+3. Selects "10-Q | 2023-08-04" in Filing B
+4. Both selections are independent — each panel retains its own selection
+5. Neither selection affects the other
+
+### E2E-3: Company change resets filings
+
+1. User selects Apple Inc. → filing selectors populated
+2. User selects "10-K | 2023-11-03" in Filing A
+3. User clears search and selects Microsoft Corporation
+4. Previous filing selection is cleared
+5. Selectors reload with Microsoft's filings
+6. User can make new selections
+
+### E2E-4: Company with no supported filings
+
+1. User selects a company that has only 8-K filings
+2. Filing selectors show empty state (no options or "No supported filings")
+3. User cannot select a filing
+4. No errors displayed
+
+### E2E-5: Company clear resets everything
+
+1. User selects Apple Inc. → selects filings in both panels
+2. User clears the search input
+3. Both filing selectors revert to disabled state with placeholder
+4. No stale filing data visible
+
+---
+
+## 5. Boundary Conditions
+
+| Condition | Input | Expected Behavior |
+|-----------|-------|-------------------|
+| 0 filings after filtering | Company with only 8-K filings | Empty dropdown, selector disabled or shows "No supported filings" |
+| 1 filing | Company with single 10-K | Dropdown with 1 option |
+| Many filings (50+) | Company with 50+ supported filings | All rendered in dropdown, scrollable, sorted by date desc |
+| Empty response arrays | `{ accessionNumber: [], filingDate: [], form: [] }` | Empty dropdown, no crash |
+| Company with mixed form types | 3 supported + 5 unsupported | Only 3 options shown |
+| All 4 supported types present | 10-K, 10-K/A, 10-Q, 10-Q/A | All 4 shown |
+| Duplicate dates | Two 10-K filings on same date | Both shown, distinguishable by accession number or form type |
+| Company changes rapidly | Select AAPL, then MSFT immediately | Only MSFT filings shown (abort in-flight) |
+| Select then immediately clear | Select AAPL, immediately clear | No stale filings, selectors disabled |
+
+---
+
+## 6. Error Conditions
+
+| Condition | Trigger | Expected Behavior |
+|-----------|---------|-------------------|
+| Network error fetching submissions | `fetch` rejects with TypeError | Error message displayed, selectors disabled |
+| 404 — company not found | SEC API returns 404 | Error state, "Company submissions not found" |
+| 429 — rate limited | SEC API returns 429 | Error state, "Rate limited. Please wait." |
+| 500 — server error | SEC API returns 500 | Error state, "Unable to load filings" |
+| Malformed response | Missing `filings.recent` in response | Error state, "Unexpected response format" |
+| Company changes while fetch in-flight | User changes company during loading | In-flight request aborted, no stale data |
+| AbortError from cancellation | Company change aborts fetch | Silently handled (not shown as error) |
+
+> **Note:** Detailed error handling and retry logic is deferred to US-2.10. For US-2.9, we surface errors but do not implement retry mechanisms.
+
+---
+
+## 7. Test Data & Fixtures
+
+### Expanded MOCK_AAPL_SUBMISSIONS
+
+The existing `MOCK_AAPL_SUBMISSIONS` in `company-search-fixtures.ts` has only 1 filing. Expand it in-place with multiple filings of different types (including unsupported ones for filter testing). US-2.8 tests should still pass since they don't depend on the filing count.
+
+```typescript
+// Updated in apps/web/src/test-fixtures/company-search-fixtures.ts
+
+export const MOCK_AAPL_SUBMISSIONS = {
+  cik: '320193',
+  name: 'Apple Inc.',
+  tickers: ['AAPL'],
+  exchanges: ['Nasdaq'],
+  filings: {
+    recent: {
+      accessionNumber: [
+        '0000320193-23-000106',
+        '0000320193-23-000077',
+        '0000320193-23-000064',
+        '0000320193-22-000108',
+        '0000320193-23-000050',  // 8-K (should be filtered out)
+      ],
+      filingDate: [
+        '2023-11-03',
+        '2023-08-04',
+        '2023-05-05',
+        '2022-10-28',
+        '2023-09-15',
+      ],
+      form: [
+        '10-K',
+        '10-Q',
+        '10-Q',
+        '10-K',
+        '8-K',  // unsupported — should be filtered out
+      ],
+    },
+  },
+};
+
+### Additional Edge-Case Fixtures
+
+These can go in a new `apps/web/src/test-fixtures/filing-list-fixtures.ts` file since they're specific to filing selector tests and don't belong in the shared company-search fixtures.
+
+```typescript
+// apps/web/src/test-fixtures/filing-list-fixtures.ts
+
+/** Company with no supported filings (only 8-K) — matches coder's MOCK_NO_SUPPORTED_FILINGS */
+export const MOCK_NO_SUPPORTED_FILINGS = {
+  cik: '999999',
+  name: 'Only 8K Corp',
+  tickers: ['ONLY8K'],
+  exchanges: ['NYSE'],
+  filings: {
+    recent: {
+      accessionNumber: ['0000999999-23-000001'],
+      filingDate: ['2023-06-15'],
+      form: ['8-K'],
+    },
+  },
+};
+
+/** Company with mixed supported and unsupported types */
+export const MOCK_MIXED_FILINGS_SUBMISSIONS = {
+  cik: '888888',
+  name: 'Mixed Filings Inc.',
+  tickers: ['MXFD'],
+  exchanges: ['Nasdaq'],
+  filings: {
+    recent: {
+      accessionNumber: [
+        '0000888888-23-000001',
+        '0000888888-23-000002',
+        '0000888888-23-000003',
+        '0000888888-23-000004',
+        '0000888888-23-000005',
+      ],
+      filingDate: [
+        '2023-12-01',
+        '2023-11-15',
+        '2023-09-01',
+        '2023-06-15',
+        '2023-03-01',
+      ],
+      form: [
+        '10-K',
+        '8-K',
+        '10-Q',
+        'S-1',
+        '10-K/A',
+      ],
+    },
+  },
+};
+
+/** Company with all 4 supported form types */
+export const MOCK_ALL_SUPPORTED_SUBMISSIONS = {
+  cik: '777777',
+  name: 'All Supported Corp.',
+  tickers: ['ALLQ'],
+  exchanges: ['NYSE'],
+  filings: {
+    recent: {
+      accessionNumber: [
+        '0000777777-23-000001',
+        '0000777777-23-000002',
+        '0000777777-23-000003',
+        '0000777777-23-000004',
+      ],
+      filingDate: [
+        '2023-12-15',
+        '2023-09-15',
+        '2023-06-15',
+        '2023-03-15',
+      ],
+      form: [
+        '10-K',
+        '10-K/A',
+        '10-Q',
+        '10-Q/A',
+      ],
+    },
+  },
+};
+
+/** Empty filings (company with no recent filings) */
+export const MOCK_EMPTY_FILINGS_SUBMISSIONS = {
+  cik: '666666',
+  name: 'Empty Filings LLC',
+  tickers: ['EMPT'],
+  exchanges: ['Nasdaq'],
+  filings: {
+    recent: {
+      accessionNumber: [],
+      filingDate: [],
+      form: [],
+    },
+  },
+};
+
+/** Large set of filings (50+) for scroll/performance testing */
+export function createLargeFilingsSubmissions(count: number = 50) {
+  const accessionNumber: string[] = [];
+  const filingDate: string[] = [];
+  const form: string[] = [];
+  const formTypes = ['10-K', '10-Q', '10-Q', '10-Q']; // 1 annual + 3 quarterly per year
+
+  for (let i = 0; i < count; i++) {
+    const year = 2023 - Math.floor(i / 4);
+    const quarter = i % 4;
+    const month = String(11 - quarter * 3).padStart(2, '0');
+    accessionNumber.push(`0000555555-${year}-${String(i).padStart(6, '0')}`);
+    filingDate.push(`${year}-${month}-03`);
+    form.push(formTypes[quarter]);
+  }
+
+  return {
+    cik: '555555',
+    name: 'Large Filings Corp.',
+    tickers: ['LRGF'],
+    exchanges: ['NYSE'],
+    filings: {
+      recent: { accessionNumber, filingDate, form },
+    },
+  };
+}
+```
+
+### AvailableFiling Type (new in `services/types.ts`)
+
+```typescript
+/** A filing available for selection in the filing dropdown. */
+export interface AvailableFiling {
+  /** SEC accession number (unique identifier) */
+  accessionNumber: string;
+  /** Filing date (YYYY-MM-DD string) */
+  filingDate: string;
+  /** Form type (10-K, 10-K/A, 10-Q, 10-Q/A) */
+  formType: string;
+}
+```
+
+### Filing List Status Type (new in `services/types.ts`)
+
+```typescript
+/** States the filing list can be in. */
+export type FilingListStatus = 'idle' | 'loading' | 'loaded' | 'error';
+```
+
+### Mock Fetch for Filing Tests
+
+Extend the existing `createStandardMockFetch` pattern:
+
+```typescript
+/** Creates a mock fetch for filing list tests with configurable submissions response */
+export function createFilingMockFetch(
+  submissionsResponse: Response | (() => Response),
+) {
+  return createMockFetch({
+    '/api/sec/submissions/': submissionsResponse,
+  });
+}
+```
+
+---
+
+## 8. Test Configuration Notes
+
+### Mock Strategy
+
+- **Service tests:** No mocking needed — test pure functions with fixture data directly
+- **Hook tests:** Mock the `filing-list` service module via `vi.mock()`. Use `renderHook` from `@testing-library/react`
+- **Component tests:** `FilingSelector` is purely presentational — render with different prop combinations, no mocking needed. `FilingPanel` tests mock `FilingSelector` or render with props directly.
+- **Integration tests:** Mock `globalThis.fetch` at the boundary; use real hooks and components
+- **Timer mocking:** Not needed for US-2.9 (no debounce); standard `act()` wrapping for async state updates
+
+### Test Isolation
+
+- Each test renders a fresh component instance
+- Mock fetch reset between tests (`vi.restoreAllMocks()` in `afterEach`)
+- FilingSelector tests reset `onSelect` mock via `vi.fn()` in `beforeEach`
+
+---
+
+## 9. UAT Scenarios (Chrome DevTools MCP)
+
+Visual and interaction checks performed against the running dev server after all automated tests pass.
+
+**Full UAT document:** See [uat.md](uat.md) for the complete UAT plan with prerequisites, verify steps, reference screenshot placeholders, and pass/fail criteria.
+
+**Summary of UAT coverage:**
+
+| UAT Step | What it covers |
+|----------|----------------|
+| UAT-1 | Filing selectors default state (disabled, placeholder) |
+| UAT-2 | Selectors enable after company selection |
+| UAT-3 | Dropdown shows filtered and sorted filings |
+| UAT-4 | Filing selection works in Filing A |
+| UAT-5 | Filing selection works in Filing B |
+| UAT-6 | Independent selections in both panels |
+| UAT-7 | Company change resets selectors |
+| UAT-8 | Company clear disables selectors |
+| UAT-9 | Loading state during fetch |
+| UAT-10 | Responsive at 768px |
+| UAT-11 | Responsive at 375px |
+| UAT-12 | No console errors |
+
+---
+
+## 10. Coverage Matrix
+
+| Acceptance Criterion | Unit | Integration | E2E/UAT |
+|---------------------|------|-------------|---------|
+| Filing selectors appear after company selection | FilingSelector render tests | App integration | UAT-2 |
+| Dropdown lists filings with form type + date | FilingSelector option tests | Full flow | UAT-3 |
+| Filings sorted by date descending | filing-list service sort tests | Full flow | UAT-3 |
+| Only supported form types shown | filing-list service filter tests | Full flow | UAT-3 |
+| Both panels have independent selectors | FilingSelector callback tests | App integration | UAT-4, UAT-5, UAT-6 |
+| Selecting filing triggers callback | FilingSelector interaction tests | Full flow | UAT-4, UAT-5 |
+| Selectors disabled without company | FilingSelector disabled tests | App integration | UAT-1, UAT-8 |
+| Company change reloads filings | useFilingList abort/reload tests | App integration | UAT-7 |
+| Empty/filtered filings handled | filing-list edge case tests | — | — |
+| Error states displayed | useFilingList error tests, FilingSelector error tests | — | — |
+| Responsive layout | — | — | UAT-10, UAT-11 |
+| No console errors | — | — | UAT-12 |

--- a/.specs/us-2-9-filing-selectors/uat.md
+++ b/.specs/us-2-9-filing-selectors/uat.md
@@ -1,0 +1,217 @@
+# US-2.9: Filing Selectors — UAT
+
+Manual acceptance tests executed by a tester agent via Chrome DevTools MCP at the end of the dev/test cycle. These are **not** automated Vitest tests — they are visual sanity checks that verify the rendered page matches the design intent.
+
+**Recording requirements:** Screenshots MUST be saved to `.specs/us-2-9-filing-selectors/screenshots/` and committed alongside the implementation. UAT results (pass/fail for each step, with a brief summary) MUST be recorded in the implementation PR body or as a PR comment, with screenshots attached/embedded so reviewers can see the visual verification without running the app.
+
+## Prerequisites
+
+- Dev server running: `NX_OUTPUT_STYLE=stream pnpm nx run web:dev`
+- Chrome DevTools MCP connected
+- Default viewport: 1280x800
+- Company search feature (US-2.8) implemented and working
+- Filing selector feature (US-2.9) implemented
+- Worker endpoint available (local Wrangler or proxied)
+
+## Test Steps
+
+### 1. Filing Selectors — Default State (No Company Selected)
+
+**Action:** Navigate to `http://localhost:5173`
+
+**Verify:**
+- Both Filing A and Filing B panels have a dropdown/select element visible
+- Both selectors are disabled (grayed out, cursor-not-allowed)
+- Both show placeholder text "Select a filing..."
+- Selectors are visually consistent between the two panels (same size, alignment, styling)
+- No layout shift or clipping around the selectors
+
+<!-- Reference screenshot: screenshots/01-selectors-disabled.png -->
+
+---
+
+### 2. Filing Selectors — Enabled After Company Selection
+
+**Action:** Search for "AAPL" in the search bar, select "Apple Inc." from the dropdown, and wait for the company to resolve
+
+**Verify:**
+- Both filing selectors transition from disabled to enabled
+- Placeholder text changes or remains as "Select a filing..." but selector is now interactive
+- No layout shift when selectors become enabled
+- The transition is smooth (no flash of unstyled content)
+
+<!-- Reference screenshot: screenshots/02-selectors-enabled.png -->
+
+---
+
+### 3. Filing Dropdown — Options Display
+
+**Action:** Click on the Filing A selector to open the dropdown
+
+**Verify:**
+- Dropdown opens and shows a list of filings
+- Each option displays form type and filing date (e.g., "10-K | 2023-11-03")
+- Options are sorted by date with most recent first
+- Only supported form types appear (10-K, 10-K/A, 10-Q, 10-Q/A — no 8-K, S-1, etc.)
+- Dropdown is readable and options are not truncated or overlapping
+- Dropdown has clear visual boundaries
+
+<!-- Reference screenshot: screenshots/03-dropdown-options.png -->
+
+---
+
+### 4. Filing Selection — Filing A
+
+**Action:** Select a filing from the Filing A dropdown (e.g., "10-K | 2023-11-03")
+
+**Verify:**
+- Selected filing is displayed in the selector
+- Dropdown closes after selection
+- The selected option text is fully visible in the closed selector
+- No visual artifacts or stale text
+
+<!-- Reference screenshot: screenshots/04-filing-a-selected.png -->
+
+---
+
+### 5. Filing Selection — Filing B
+
+**Action:** Click on the Filing B selector and select a different filing (e.g., "10-Q | 2023-08-04")
+
+**Verify:**
+- Filing B dropdown shows the same list of filings as Filing A
+- Selected filing is displayed in the Filing B selector
+- Filing A retains its previous selection (still shows "10-K | 2023-11-03")
+- Both selectors show their respective selections independently
+
+<!-- Reference screenshot: screenshots/05-filing-b-selected.png -->
+
+---
+
+### 6. Independent Selections — Both Panels
+
+**Action:** Verify both panels after making different selections in step 4 and step 5
+
+**Verify:**
+- Filing A shows "10-K | 2023-11-03" (or whichever was selected)
+- Filing B shows "10-Q | 2023-08-04" (or whichever was selected)
+- Neither selection has overwritten the other
+- Both selectors remain interactive (can change selections)
+
+<!-- Reference screenshot: screenshots/06-independent-selections.png -->
+
+---
+
+### 7. Company Change — Selectors Reset
+
+**Action:** Clear the search bar and search for a different company (e.g., "MSFT"), select "Microsoft Corporation"
+
+**Verify:**
+- Previous filing selections are cleared from both selectors
+- Both selectors reload with Microsoft's filings
+- Filing options show Microsoft's filing dates (different from Apple's)
+- Selectors are enabled and interactive with new data
+- No stale Apple filing data visible
+
+<!-- Reference screenshot: screenshots/07-company-change-reset.png -->
+
+---
+
+### 8. Company Clear — Selectors Disable
+
+**Action:** Clear the search input entirely (click the clear button or delete all text)
+
+**Verify:**
+- Both filing selectors revert to disabled state
+- Both show placeholder text "Select a filing..."
+- Both are grayed out with cursor-not-allowed
+- No stale filing data visible
+- State matches the initial load (step 1)
+
+<!-- Reference screenshot: screenshots/08-selectors-after-clear.png -->
+
+---
+
+### 9. Loading State — During Filing Fetch
+
+**Action:** Search for a company and observe the filing selectors during the submissions API call
+
+**Verify:**
+- A loading indicator is visible while filings are being fetched (spinner, text, or skeleton)
+- Selectors are disabled during loading
+- Loading indicator disappears once filings are loaded
+- Transition from loading to populated is smooth
+
+<!-- Reference screenshot: screenshots/09-loading-state.png -->
+
+---
+
+### 10. Responsive — Narrow Viewport (768px)
+
+**Action:** Resize viewport to 768x800. Select a company and interact with filing selectors.
+
+**Verify:**
+- Filing selectors adapt to narrower panel width
+- Dropdown options are readable (text may truncate with ellipsis if needed)
+- Selectors are still usable (can open, select, close)
+- No horizontal overflow or layout breakage
+- Both panels remain visible side by side (or stack appropriately)
+
+<!-- Reference screenshot: screenshots/10-responsive-768.png -->
+
+---
+
+### 11. Responsive — Mobile Viewport (375px)
+
+**Action:** Resize viewport to 375x800. Select a company and interact with filing selectors.
+
+**Verify:**
+- Filing selectors fill available width within their panels
+- Dropdown is usable (not clipped or overflowing viewport)
+- Touch targets are adequately sized
+- Option text wraps or truncates readably
+- No layout breakage
+
+<!-- Reference screenshot: screenshots/11-responsive-375.png -->
+
+---
+
+### 12. No Console Errors During Interaction
+
+**Action:** Open browser DevTools console. Perform full flow: select company → open dropdowns → select filings → change company → clear search.
+
+**Verify:**
+- No JavaScript errors in the console
+- No React warnings (missing keys, prop type errors, state-update-on-unmounted)
+- No failed network requests (other than intentionally triggered errors)
+- No CORS errors
+- No abort-related errors logged
+
+<!-- Reference screenshot: screenshots/12-no-console-errors.png -->
+
+---
+
+## Reference Screenshots
+
+Screenshots are captured during implementation and stored alongside this UAT doc for future comparison. They serve as informal visual baselines — not pixel-perfect regression tests.
+
+```
+.specs/us-2-9-filing-selectors/screenshots/
+  01-selectors-disabled.png
+  02-selectors-enabled.png
+  03-dropdown-options.png
+  04-filing-a-selected.png
+  05-filing-b-selected.png
+  06-independent-selections.png
+  07-company-change-reset.png
+  08-selectors-after-clear.png
+  09-loading-state.png
+  10-responsive-768.png
+  11-responsive-375.png
+  12-no-console-errors.png
+```
+
+## Pass/Fail Criteria
+
+- **Pass:** All 12 steps verified. Filing selectors render correctly in disabled and enabled states. Dropdowns show filtered (supported types only) and sorted (most recent first) filings. Selections work independently in both panels. Company changes and clears properly reset selectors. Loading state is visible during fetch. Responsive layout holds at 768px and 375px. No console errors during the full interaction flow.
+- **Fail:** Any step shows broken layout, missing or incorrect filing options, stale data after company change/clear, dependent selections between panels, missing loading state, console errors, or broken responsive behavior.


### PR DESCRIPTION
## Summary

- Implementation design, test plan, and UAT doc for US-2.9: Filing Selectors
- Coder and tester agents collaborated with 1 feedback round, resolving 4 alignment issues
- Beads issue: edgar-diff-nsu

## Design Decisions

- **Service layer**: `filing-list.ts` fetches SEC submissions, parses parallel arrays, filters to 4 supported form types (10-K, 10-K/A, 10-Q, 10-Q/A), sorts by date descending
- **Hook**: `useFilingList.ts` wraps the service with abort-on-company-change
- **Component**: `FilingSelector.tsx` — native `<select>` dropdown, pure presentational
- **Wiring**: `App.tsx` manages `selectedCompany → useFilingList → FilingPanel` with independent selection state per panel
- **Fiscal period**: Deferred to US-2.12 (SEC API doesn't provide it)

## Files

| File | Description |
|------|-------------|
| `.specs/us-2-9-filing-selectors/implementation-design.md` | Implementation design |
| `.specs/us-2-9-filing-selectors/test-plan.md` | Test plan (BDD, unit, integration, E2E, boundary, error) |
| `.specs/us-2-9-filing-selectors/uat.md` | 12-step UAT for visual verification |

## Test plan

- [ ] Review implementation design for completeness and alignment with PRD
- [ ] Review test plan covers all acceptance criteria
- [ ] Review UAT steps are executable

Co-Authored-By: SageOx <ox@sageox.ai>