### PR TITLE
Add project documentation: README, CONTRIBUTING, and LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thank you for your interest in edgar-diff!
+
+## Code Contributions
+
+**We are not accepting code contributions at this time** — from humans or AI. This project was built as a focused experiment in AI-driven development, and we want to keep the codebase as-is to preserve that record.
+
+## Bug Reports and Feature Requests
+
+We **welcome** bug reports and feature requests! If you've found a problem or have an idea for improvement, please [open an issue](https://github.com/galexy/edgar-diff/issues).
+
+A great bug report includes:
+
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- Filing tickers/CIKs involved (if applicable)
+- Browser and OS (for web app issues)
+
+A great feature request includes:
+
+- The problem you're trying to solve
+- How you imagine the solution working
+- Why it matters for your workflow
+
+Well-thought-through issues are especially appreciated — they help anyone who might fork this project and build on it.
+
+## Forking
+
+You are absolutely welcome to fork this project and take it in your own direction. See the [MIT License](LICENSE) for details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 edgar-diff contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# edgar-diff
+
+**Compare SEC filings side-by-side. See exactly what changed.**
+
+edgar-diff pulls full-text filings from the SEC EDGAR database and produces structured, section-by-section diffs — turning hours of manual comparison into seconds.
+
+---
+
+> [!NOTE]
+> **This project was built entirely by AI.** Every line of code, every test, and every piece of documentation was written using AI tools (Claude) through an intentional vibe-engineering process. This was a targeted experiment in building a small, useful piece of software using AI tools exclusively — learning what works, what doesn't, and how to direct AI effectively for real engineering output. A detailed write-up of the process is forthcoming.
+
+> [!WARNING]
+> **This project is not actively maintained.** It was built as a learning experiment. You are welcome to use it, fork it, and build on it, but don't expect ongoing updates or support.
+
+---
+
+## What It Does
+
+- **Side-by-side diff view** — Additions, deletions, and modifications highlighted inline, organized by filing section (Risk Factors, MD&A, Financial Statements, etc.)
+- **Structured parsing** — Filings are parsed into semantic sections, not treated as raw text blobs. A renamed section won't show up as a full delete + add.
+- **Direct EDGAR integration** — Pulls filings straight from SEC EDGAR. No third-party data dependency.
+- **Reusable diff library** — The core engine (`@edgar-diff/lib`) is decoupled from the UI and can be embedded in pipelines, monitors, or other tools.
+
+## Project Structure
+
+```
+edgar-diff/
+├── apps/web/          # React web application (Vite + Cloudflare Workers)
+├── libs/edgar-diff-lib/  # Core library: EDGAR client, filing parser, diff engine
+├── scripts/           # Dev utilities (filing analysis, fetching)
+└── docs/              # Setup guides and development docs
+```
+
+**Monorepo** managed with [pnpm workspaces](https://pnpm.io/workspaces) and [Nx](https://nx.dev/) for task orchestration.
+
+## Tech Stack
+
+- **Runtime:** Node.js >= 20
+- **Package Manager:** pnpm (via corepack)
+- **Build/Task Runner:** Nx
+- **Language:** TypeScript
+- **Web App:** React 19, Vite, Tailwind CSS, Cloudflare Workers
+- **Testing:** Vitest, Testing Library, fast-check (property-based)
+- **Core Lib:** htmlparser2, diff, jaro-winkler (section matching)
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 20
+- Git
+
+### Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/galexy/edgar-diff.git
+cd edgar-diff
+
+# Enable corepack (provides pnpm — do NOT install pnpm globally)
+corepack enable
+
+# Install dependencies
+pnpm install
+
+# Verify everything works
+pnpm nx run-many --target=typecheck
+pnpm nx run-many --target=test
+```
+
+### Running the Web App
+
+```bash
+pnpm nx dev web
+```
+
+### Running Tests
+
+```bash
+# All tests (unit + integration + fixture-based e2e)
+pnpm nx run-many --target=test
+
+# Single project
+pnpm nx test edgar-diff-lib
+
+# Only affected projects (faster for incremental work)
+pnpm nx affected --target=test
+
+# Lint
+pnpm nx run-many --target=lint
+
+# Typecheck
+pnpm nx run-many --target=typecheck
+```
+
+### Common Issues
+
+| Problem | Fix |
+|---|---|
+| `pnpm: command not found` | Run `corepack enable` |
+| pnpm version mismatch | Remove global pnpm: `npm uninstall -g pnpm && corepack enable` |
+| `nx: command not found` | Use `pnpm nx ...` (Nx is a devDependency, not global) |
+| `Cannot find module` after branch switch | `pnpm install && pnpm nx reset` |
+
+See [docs/setup.md](docs/setup.md) for more detailed troubleshooting.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ edgar-diff pulls full-text filings from the SEC EDGAR database and produces stru
 
 ## What It Does
 
-- **Side-by-side diff view** — Additions, deletions, and modifications highlighted inline, organized by filing section (Risk Factors, MD&A, Financial Statements, etc.)
-- **Structured parsing** — Filings are parsed into semantic sections, not treated as raw text blobs. A renamed section won't show up as a full delete + add.
-- **Direct EDGAR integration** — Pulls filings straight from SEC EDGAR. No third-party data dependency.
-- **Reusable diff library** — The core engine (`@edgar-diff/lib`) is decoupled from the UI and can be embedded in pipelines, monitors, or other tools.
+- 🔍 **Side-by-side diff view** — Additions, deletions, and modifications highlighted inline, organized by filing section (Risk Factors, MD&A, Financial Statements, etc.)
+- 🧩 **Structured parsing** — Filings are parsed into semantic sections, not treated as raw text blobs. A renamed section won't show up as a full delete + add.
+- 📡 **Direct EDGAR integration** — Pulls filings straight from SEC EDGAR. No third-party data dependency.
+- 🔧 **Reusable diff library** — The core engine (`@edgar-diff/lib`) is decoupled from the UI and can be embedded in pipelines, monitors, or other tools.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ edgar-diff pulls full-text filings from the SEC EDGAR database and produces stru
 
 ## What It Does
 
-- 🔍 **Side-by-side diff view** — Additions, deletions, and modifications highlighted inline, organized by filing section (Risk Factors, MD&A, Financial Statements, etc.)
-- 🧩 **Structured parsing** — Filings are parsed into semantic sections, not treated as raw text blobs. A renamed section won't show up as a full delete + add.
+- ↔️ **Side-by-side diff view** — Additions, deletions, and modifications highlighted inline, organized by filing section (Risk Factors, MD&A, Financial Statements, etc.)
+- 🗂️ **Structured parsing** — Filings are parsed into semantic sections, not treated as raw text blobs. A renamed section won't show up as a full delete + add.
 - 📡 **Direct EDGAR integration** — Pulls filings straight from SEC EDGAR. No third-party data dependency.
-- 🔧 **Reusable diff library** — The core engine (`@edgar-diff/lib`) is decoupled from the UI and can be embedded in pipelines, monitors, or other tools.
+- 📦 **Reusable diff library** — The core engine (`@edgar-diff/lib`) is decoupled from the UI and can be embedded in pipelines, monitors, or other tools.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/hero.png" alt="edgar-diff — side-by-side SEC filing comparison showing additions, deletions, and modifications" width="800" />
+</p>
+
 # edgar-diff
 
 **Compare SEC filings side-by-side. See exactly what changed.**

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ pnpm nx run-many --target=test
 pnpm nx dev web
 ```
 
+Once the dev server is running:
+
+1. Open your browser at [http://localhost:5173](http://localhost:5173)
+2. Search for a company by name or ticker symbol (e.g. "AAPL" or "Apple")
+3. Select two recent SEC filings to compare (e.g. two consecutive 10-K annual reports)
+4. View the structured, section-by-section diff with additions, deletions, and modifications highlighted
+
+<!-- TODO: Add screenshot of the app in action -->
+<p align="center">
+  <img src="assets/app-screenshot.png" alt="edgar-diff app screenshot showing a side-by-side filing comparison" width="800" />
+</p>
+
 ### Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary

This PR adds comprehensive project documentation to establish the foundation for the edgar-diff repository. These files provide setup instructions, contribution guidelines, and licensing information for users and potential contributors.

## Changes

- **README.md** — Complete project overview including:
  - High-level description of edgar-diff's purpose and capabilities
  - Transparency note about the project being AI-built as a learning experiment
  - Maintenance status disclaimer
  - Feature summary (side-by-side diffs, structured parsing, EDGAR integration, reusable library)
  - Project structure and tech stack overview
  - Getting started guide with prerequisites, setup steps, and common troubleshooting
  
- **CONTRIBUTING.md** — Contribution guidelines clarifying:
  - Current policy: not accepting code contributions (to preserve the AI-built experiment record)
  - Welcome for bug reports and feature requests with guidance on quality submissions
  - Encouragement for forking and building on the project
  
- **LICENSE** — MIT License establishing permissive open-source terms

## Notes

These documentation files establish the project's public-facing identity and set clear expectations around maintenance, contribution, and usage. The README provides practical onboarding for developers, while CONTRIBUTING and LICENSE clarify the project's experimental nature and open-source terms.

https://claude.ai/code/session_01B1Z5NJwk12VWqCoZp8UdKm